### PR TITLE
Fix error when expiration time of token is inf+

### DIFF
--- a/src/ciao.lisp
+++ b/src/ciao.lisp
@@ -136,7 +136,8 @@ relevant to access Clio services")
                            (re-acquire? t)
                            (who #'get-access-token))
   "Returns the access-token for an oauth2 object"
-  (cond ((< (get-universal-time) (get-expiration oauth))
+  (cond (((or (eq 'inf+ (get-expiration oauth)) 
+              (< (get-universal-time) (get-expiration oauth)))
          (slot-value oauth 'access-token))
         (re-acquire?
          (re-acquire-token! oauth :who who)


### PR DESCRIPTION
Under SBCL, trying to compare `(get-universal-time)` to the symbol `inf+` gives an error.